### PR TITLE
removed kwm and added kitty to docs

### DIFF
--- a/resources.md
+++ b/resources.md
@@ -102,7 +102,6 @@ It can be part of a desktop environment (DE) or be used standalone.
 #### OSX
 - [Spectacle](https://www.spectacleapp.com/)
 - [Mjolnir](https://github.com/sdegutis/mjolnir)
-- [KWM](https://github.com/koekeishiya/kwm)
 - [chunkwm](https://github.com/koekeishiya/chunkwm)
 - [Phoenix](https://github.com/kasper/phoenix)
 - [ShiftIt](https://github.com/fikovnik/ShiftIt)
@@ -198,6 +197,7 @@ WSL Terminals:
 
 #### OSX
 - [Iterm2](https://www.iterm2.com)
+- [kitty](https://github.com/kovidgoyal/kitty)
 - [cool-retro-term](https://github.com/Swordfish90/cool-retro-term)
 
 # Shells


### PR DESCRIPTION
Looking at [KWM's repo](https://github.com/koekeishiya/kwm), the project is now deprecated. Furthermore, the maintainers have moved on to [chunkwm](https://github.com/koekeishiya/chunkwm) which is in all respects better and already listed in the rice resources.

Kitty is added as a new option that is made for linux, but also maintained for OSX. It is one of the very few rice-friendly terminals for OSX in that it is configured similar to URXVT, but it is faster than iterm or even xterm. It is incredibly light weight compared to iterm so I am debating the location of it being first choice for OSX terminals, but it is new so maybe this can wait.

I am considering adding kitty to linux terminals and I can modify the pull request to add this, but I think extra input would be appreciated since it is my opinion that Linux Terminals recommended by rice should maintain a certain level of quality.